### PR TITLE
new mug every time

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -249,12 +249,6 @@ export default {
     },
 
     zazzleMugPrint() {
-      if (this.zazzleLink) {
-        window.open(this.zazzleLink, '_blank');
-        recordOpenClick(this.zazzleLink);
-        return;
-      }
-
       let printableCanvas = this.getPrintableCanvas();
 
       this.generatingPreview = true;


### PR DESCRIPTION
Found it confusing that mug link is only created once per map load. 
As far as I checked zazzle doesn't have explicit api restrictions therefore new mug on each link click would be at no additional cost. 