### PR TITLE
Security: Global exposure of internal APIs on `window` increases XSS impact

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,8 +12,10 @@ import Query from './lib/Query.js';
 window.addEventListener('error', logError);
 
 // expose the console API
-window.requireModule = d3Require;
-window.Query = Query;
+if (process.env.NODE_ENV !== 'production') {
+  window.requireModule = d3Require;
+  window.Query = Query;
+}
 
 if (isWebGLEnabled(document.querySelector('#canvas'))) {
   createApp(App).mount('#host');


### PR DESCRIPTION
## Problem

`window.requireModule = d3Require` and `window.Query = Query` expose powerful internals globally. If any script injection occurs (including via third-party scripts), attackers can directly use these objects to load modules, issue requests, and exfiltrate data, significantly increasing blast radius.

**Severity**: `medium`
**File**: `src/main.js`

## Solution

Remove global exports in production builds, or gate them behind a strict development flag. Keep debug APIs in a local module scope and avoid attaching them to `window`.

## Changes

- `src/main.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
